### PR TITLE
Clarified kata requirements and fixed tests for conjured items.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Modified by me from the original, found at https://github.com/istepaniuk/gilded-rose-js-with-tests, in the following ways:
 
-0. It's in Python 3 now.  So, really the only original content is the README from "Coding Dojo" on
+0. It's in Python 3 now.  So, really the only original content is the README from "Coding Dojo" on [insert link, I propose this repo](https://github.com/emilybache/GildedRose-Refactoring-Kata)
 
 ## Installing
 
@@ -29,7 +29,7 @@ The final test, which relates to a new feature, is skipped.  Remove the `@skip` 
 Coding Dojo
 ===========
 
-Note that this Kata has been slightly modified from [the original](http://iamnotmyself.com/2011/02/13/refactor-this-the-gilded-rose-kata/) by Terry Hughes and Bobby Johnson. Namely, in the original Kata the Brie Cheese does not behave exactly like the Backstage passes as this code does. I also think the original kata has a bug on purpose so you have to fix it. This version was used in the Madrid Software Craftsmanship meetup group, and we wanted to focus on refactoring. We had limited time, so the tests are already written and green. [This is a post in my blog about that meeting.](http://blog.istepaniuk.com/refactoring-dojo-the-gilded-rose-kata)
+Note that this Kata has been slightly modified from [the original, this link returns 404 now](http://iamnotmyself.com/2011/02/13/refactor-this-the-gilded-rose-kata/) by Terry Hughes and Bobby Johnson. Namely, in the original Kata the Brie Cheese does not behave exactly like the Backstage passes as this code does. I also think the original kata has a bug on purpose so you have to fix it. This version was used in the Madrid Software Craftsmanship meetup group, and we wanted to focus on refactoring. We had limited time, so the tests are already written and green. [This is a post in my blog about that meeting.](http://blog.istepaniuk.com/refactoring-dojo-the-gilded-rose-kata)
 
 Gilded Rose
 ===========
@@ -49,12 +49,11 @@ Pretty simple, right? Well this is where it gets interesting:
 
  - Once the sell by date has passed, Quality degrades twice as fast.
  - The Quality of an item is never negative.
- - "Aged Brie" increases in Quality the older it gets.
  - The Quality of an item is never more than 50, but "Sulfuras" is a legendary item and as such its Quality is always 80 and it never alters.
- - "Backstage passes", like "Aged Brie", increases by one in Quality as its SellIn date approaches
+ - Unlike normal items, both "Backstage passes" AND "Aged Brie" increase by one in Quality as their SellIn date approaches
      - Quality increases by 2 when there are 10 days or less 
      - Quality increases by 3 when there are 5 days or less 
-     - Quality drops to 0 after the concert
+     - Quality drops to 0 after the concert/it goes bad
 
 We have recently signed a supplier of conjured items. This requires AN UPDATE to our system:
 

--- a/gilded_rose_test.py
+++ b/gilded_rose_test.py
@@ -61,13 +61,13 @@ class GildedRoseTest(TestCase):
             self.assertEqual(item.quality, expectation['quality'])
             self.assertEqual(item.sell_in, expectation['sell_in'])
 
-    def test_quality_and_sellin_decrease_twice_as_fast_after_sell_by(self):
+    def test_quality_decreases_twice_as_fast_after_sell_by(self):
         self.items.append(Item("+5 Dexterity Vest", 0, 20))
         self.items.append(Item("Conjured Mana Cake", 0, 6))
         gilded_rose.update_quality(self.items)
         expected = [
             {'sell_in': -1, 'quality': 18},
-            {'sell_in': -1, 'quality': 4},
+            {'sell_in': -1, 'quality': 2},
         ]
 
         for index, expectation in enumerate(expected):
@@ -109,7 +109,7 @@ class GildedRoseTest(TestCase):
     def test_conjured_items_decrease_in_quality_twice_as_fast(self):
         self.items.append(Item("Conjured Mana Cake", 3, 6))
         gilded_rose.update_quality(self.items)
-        expected = {'sell_in': 2, 'quality': 2}
+        expected = {'sell_in': 2, 'quality': 4}
         item = self.items[0]
         self.assertEqual(item.quality, expected['quality'])
         self.assertEqual(item.sell_in, expected['sell_in'])


### PR DESCRIPTION
In the repo this was taken from, namely https://github.com/istepaniuk/gilded-rose-js-with-tests it says:

> Note that this Kata has been slightly modified from [the original](http://iamnotmyself.com/2011/02/13/refactor-this-the-gilded-rose-kata/) by Terry Hughes and Bobby Johnson. Namely, in the original Kata the Brie Cheese does not behave exactly like the Backstage passes as this code does.

This should be indicated in this repo as well. I also noticed that tests for conjured items were the wrong way around: the quality is being deducted twice as fast in the wrong test. Because of this change, the unskipped test will return an error for the starter code. It can be commented out, but perhaps there's a better way I don't know.